### PR TITLE
Fix incorrect shield for codecov.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-[![Build Status](https://travis-ci.org/Bazinga5/tic-tac-toe.png)](https://travis-ci.org/Bazinga5/tic-tac-toe) [![Codecov](https://img.shields.io/codecov/c/github/bazinga5/tic-tac-toe.svg)](https://codecov.io/github/Bazinga5/tic-tac-toe)
+[![Build Status](https://travis-ci.org/Bazinga5/tic-tac-toe.png)](https://travis-ci.org/Bazinga5/tic-tac-toe) 
+[![codecov.io](https://codecov.io/github/Bazinga5/tic-tac-toe/coverage.svg?branch=master)](https://codecov
+.io/github/Bazinga5/tic-tac-toe?branch=master)
 
 # Tic
 


### PR DESCRIPTION
## Monitors master:

Looks like this 
[![codecov.io](https://codecov.io/github/Bazinga5/tic-tac-toe/coverage.svg?branch=master)](https://codecov.io/github/Bazinga5/tic-tac-toe?branch=master)